### PR TITLE
BBL-80 -  Ref Architecture AWS Kops Updated

### DIFF
--- a/1-prerequisites/bucket.tf
+++ b/1-prerequisites/bucket.tf
@@ -2,7 +2,7 @@
 # Bucket used to store Kops state
 #
 resource "aws_s3_bucket" "kops_state" {
-  bucket = "${var.project}-${var.environment}-kops-state"
+  bucket = "${var.project}-${var.environment}-kops-state-${local.k8s_cluster_name}"
   acl    = "private"
   # force_destroy = true
 
@@ -43,7 +43,7 @@ resource "aws_s3_bucket" "kops_state" {
 # replica over us-west-2
 # replica resource destination
 resource "aws_s3_bucket" "kops_state_replica" {
-  bucket   = "${var.project}-${var.environment}-kops-state-replica"
+  bucket   = "${var.project}-${var.environment}-kops-state-replica-${local.k8s_cluster_name}"
   provider = aws.region_secondary
 
   versioning {

--- a/1-prerequisites/locals.tf
+++ b/1-prerequisites/locals.tf
@@ -14,6 +14,16 @@ locals {
   # The kubernetes version
   k8s_cluster_version = "1.14.10"
 
+  # The etcd version
+  # Ref1: https://github.com/kubernetes/kops/blob/master/docs/cluster_spec.md#etcdclusters-v3--tls
+  # Ref2: https://github.com/etcd-io/etcd/releases
+  etcd_clusters_version = "3.3.13"
+
+  # The Calico Network CNI version
+  # Ref1: https://github.com/kubernetes/kops/blob/master/docs/calico-v3.md
+  # Ref2: Ref2: https://itnext.io/benchmark-results-of-kubernetes-network-plugins-cni-over-10gbit-s-network-36475925a560
+  networking_calico_major_version = "v3"
+
   # Kops AMI Identifier
   kops_ami_id = "kope.io/k8s-1.14-debian-stretch-amd64-hvm-ebs-2019-09-26"
 
@@ -27,12 +37,12 @@ locals {
 
   # K8s Kops Master Nodes Machine (EC2) type and size + ASG Min-Max per AZ
   # then min/max = 1 will create 1 Master Node x AZ => 3 x Masters
-  kops_master_machine_type     = "t2.medium"
+  kops_master_machine_type     = "t2.large"
   kops_master_machine_max_size = 1
   kops_master_machine_min_size = 1
 
   # K8s Kops Worker Nodes Machine (EC2) type and size + ASG Min-Max
-  kops_worker_machine_type     = "t2.small"
+  kops_worker_machine_type     = "t2.medium"
   kops_worker_machine_max_size = 5
   kops_worker_machine_min_size = 2
 }

--- a/1-prerequisites/outputs.tf
+++ b/1-prerequisites/outputs.tf
@@ -21,6 +21,14 @@ output "cluster_version" {
   description = "Kubernetes version"
   value       = local.k8s_cluster_version
 }
+output "etcd_clusters_version" {
+  description = "etcd version"
+  value       = local.etcd_clusters_version
+}
+output "networking_calico_major_version" {
+  description = "Calico network CNI major version"
+  value       = local.networking_calico_major_version
+}
 
 #
 # Cluster Master Instance Group (IG)
@@ -58,15 +66,15 @@ output "node_cloud_labels" {
 }
 output "kops_worker_machine_type" {
   description = "K8s Kops Worker Nodes Machine (EC2) type and size"
-  value       = local.kops_master_machine_type
+  value       = local.kops_worker_machine_type
 }
 output "kops_worker_machine_max_size" {
   description = "K8s Kops Worker Nodes ASG max size"
-  value       = local.kops_master_machine_max_size
+  value       = local.kops_worker_machine_max_size
 }
 output "kops_worker_machine_min_size" {
   description = "K8s Kops Worker Nodes ASG min size"
-  value       = local.kops_master_machine_min_size
+  value       = local.kops_worker_machine_min_size
 }
 
 #

--- a/2-kops/Makefile
+++ b/2-kops/Makefile
@@ -66,11 +66,12 @@ diff: ## Terraform plan with landscape
 	-var-file=${TF_DOCKER_EXTRA_CONF_VARS_FILE} ${TF_PWD_CONT_DIR} \
 	| docker run -i --rm binbash/terraform-landscape
 
-apply: ## Make terraform apply any changes with local binary
-	terraform apply \
-	 -var-file=..${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
-	 -var-file=..${TF_DOCKER_BASE_CONF_VARS_FILE} \
-	 -var-file=..${TF_DOCKER_EXTRA_CONF_VARS_FILE}
+apply: apply-cmd tf-dir-chmod ## Make terraform apply any changes with dockerized binary
+apply-cmd:
+	${TF_CMD_PREFIX} apply \
+	-var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_BASE_CONF_VARS_FILE} \
+	-var-file=${TF_DOCKER_EXTRA_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
 
 output: ## Terraform output command is used to extract the value of an output variable from the state file.
 	${TF_CMD_PREFIX} output

--- a/2-kops/Makefile.kubectl
+++ b/2-kops/Makefile.kubectl
@@ -1,0 +1,113 @@
+.PHONY: build
+#DOCKER_TAG := v1.11.10
+#DOCKER_TAG := v1.12.10
+#DOCKER_TAG := v1.13.8
+DOCKER_TAG := v1.14.4
+#DOCKER_TAG := v1.15.1
+
+LOCAL_OS_KUBE_DIR := ~/.kube
+LOCAL_OS_RESOLV_CONF := /etc/resolv.conf
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_HOME_DIR_ESCAPED := \\/home\\/${LOCAL_OS_USER}
+DOCKER_IMG_NAME = k8s-kubectx
+DOCKER_IMG_USER = root
+K8S_CONTEXT := cluster-kops-1.k8s.dev.binbash.aws
+K8S_KUBECTL_CONFIG_FILE_NAME := config
+K8S_KUBECTL_CONFIG_FILE_PATH := /${DOCKER_IMG_USER}/.kube/cluster-kops-1.k8s.dev.binbash.aws
+
+define K8S_KUBE_CMD_PREFIX
+docker run -it --rm \
+-v ${LOCAL_OS_KUBE_DIR}:/${DOCKER_IMG_USER}/.kube \
+-v ${LOCAL_OS_RESOLV_CONF}:/etc/resolv.conf \
+-e "KUBECONFIG=${K8S_KUBECTL_CONFIG_FILE_PATH}" \
+binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+define K8S_KUBECTX_CMD_PREFIX
+docker run -it --rm \
+-v ${LOCAL_OS_KUBE_DIR}:/${DOCKER_IMG_USER}/.kube \
+-v ${LOCAL_OS_RESOLV_CONF}:/etc/resolv.conf \
+-e "KUBECONFIG=${K8S_KUBECTL_CONFIG_FILE_PATH}" \
+--entrypoint=/usr/local/bin/kubectx binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+define K8S_KUBENS_CMD_PREFIX
+docker run -it --rm \
+-v ${LOCAL_OS_KUBE_DIR}:/${DOCKER_IMG_USER}/.kube \
+-v ${LOCAL_OS_RESOLV_CONF}:/etc/resolv.conf \
+-e "KUBECONFIG=${K8S_KUBECTL_CONFIG_FILE_PATH}" \
+--entrypoint=/usr/local/bin/kubens binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+define K8S_KUBECTL_CMD_PREFIX
+docker run -it --rm \
+-v ${LOCAL_OS_KUBE_DIR}:/${DOCKER_IMG_USER}/.kube \
+-v ${LOCAL_OS_RESOLV_CONF}:/etc/resolv.conf \
+-e "KUBECONFIG=${K8S_KUBECTL_CONFIG_FILE_PATH}" \
+--entrypoint=/usr/local/bin/kubectl binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+define K8S_KUBECTL_CMD_BASH_PREFIX
+docker run -it --rm \
+-v ${LOCAL_OS_KUBE_DIR}:/${DOCKER_IMG_USER}/.kube \
+-v ${LOCAL_OS_RESOLV_CONF}:/etc/resolv.conf \
+-e "KUBECONFIG=${K8S_KUBECTL_CONFIG_FILE_PATH}" \
+--entrypoint=bash binbash/${DOCKER_IMG_NAME}:${DOCKER_TAG}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+test-run-kubectx-bash: ## docker run bash
+	@echo ''
+	sed -i -e "s/${LOCAL_OS_HOME_DIR_ESCAPED}/\\/${DOCKER_IMG_USER}/g" ${LOCAL_OS_KUBE_DIR}/config
+	@echo ''
+	${K8S_KUBECTL_CMD_BASH_PREFIX}
+	@echo ''
+	sed -i -e "s/\\/${DOCKER_IMG_USER}/${LOCAL_OS_HOME_DIR_ESCAPED}/g" ${LOCAL_OS_KUBE_DIR}/config
+
+test-run-kubectx-kubens-cmds: ## docker run kubectx and kubens --help to test
+	@echo ''
+	sed -i -e "s/${LOCAL_OS_HOME_DIR_ESCAPED}/\\/${DOCKER_IMG_USER}/g" ${LOCAL_OS_KUBE_DIR}/config
+	@echo ''
+	${K8S_KUBE_CMD_PREFIX} kubectx --help && kubectl config get-contexts
+	@echo ''
+	${K8S_KUBE_CMD_PREFIX} kubens --help && kubectl get ns
+	@echo ''
+	sed -i -e "s/\\/${DOCKER_IMG_USER}/${LOCAL_OS_HOME_DIR_ESCAPED}/g" ${LOCAL_OS_KUBE_DIR}/config
+
+test-run-kubectx-kubens: ## test-run: docker run with kubectx and kubens overrided entrypoints.
+	@echo ''
+	sed -i -e "s/${LOCAL_OS_HOME_DIR_ESCAPED}/\\/${DOCKER_IMG_USER}/g" ${LOCAL_OS_KUBE_DIR}/config
+	@echo ''
+	${K8S_KUBECTX_CMD_PREFIX} --help
+	@echo ''
+	${K8S_KUBECTX_CMD_PREFIX}
+	${K8S_KUBECTX_CMD_PREFIX} ${K8S_CONTEXT}
+	@echo ''
+	${K8S_KUBENS_CMD_PREFIX} --help
+	@echo ''
+	${K8S_KUBENS_CMD_PREFIX}
+	${K8S_KUBENS_CMD_PREFIX} kube-system
+	@echo ''
+	sed -i -e "s/\\/${DOCKER_IMG_USER}/${LOCAL_OS_HOME_DIR_ESCAPED}/g" ${LOCAL_OS_KUBE_DIR}/config
+
+test-run-kubectl: ## docker run kubectl commands
+	@echo ''
+	sed -i -e "s/${LOCAL_OS_HOME_DIR_ESCAPED}/\\/${DOCKER_IMG_USER}/g" ${LOCAL_OS_KUBE_DIR}/config
+	@echo ''
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} version
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} config --kubeconfig=/${DOCKER_IMG_USER}/.kube/${K8S_KUBECTL_CONFIG_FILE_NAME} view --minify
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} --context=${K8s_CONTEXT} get nodes
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} --context=${K8s_CONTEXT} get svc
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} --context=${K8s_CONTEXT} get pods --all-namespaces
+	@echo ''
+	${K8S_KUBECTL_CMD_PREFIX} --context=${K8s_CONTEXT} get pods --namespace=kube-system
+	@echo ''
+	sed -i -e "s/\\/${DOCKER_IMG_USER}/${LOCAL_OS_HOME_DIR_ESCAPED}/g" ${LOCAL_OS_KUBE_DIR}/config

--- a/2-kops/cluster-template.yml
+++ b/2-kops/cluster-template.yml
@@ -42,7 +42,7 @@ spec:
       encryptedVolume: true
   {{ end }}
     name: main
-    version: 3.3.10
+    version: {{ .etcd_clusters_version.value }}
   - etcdMembers:
   {{ range $i, $az := .cluster_master_azs.value }}
     - instanceGroup: master-{{ . }}
@@ -50,7 +50,7 @@ spec:
       encryptedVolume: true
   {{ end }}
     name: events
-    version: 3.3.10
+    version: {{ .etcd_clusters_version.value }}
   iam:
     allowContainerRegistry: true
     legacy: true
@@ -65,11 +65,10 @@ spec:
   networkID: {{ .vpc_id.value }}
   #
   # Ref1: https://github.com/kubernetes/kops/blob/master/docs/networking.md
-  # Ref2: https://itnext.io/benchmark-results-of-kubernetes-network-plugins-cni-over-10gbit-s-network-36475925a560
   #
   networking:
     calico:
-      majorVersion: v3
+      majorVersion: {{ .networking_calico_major_version.value }}
   nonMasqueradeCIDR: 100.64.0.0/10
   #
   # This array configures the CIDRs that are able to ssh into nodes. On AWS this

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ The workflow may look complicated at first but generally it boils down to these 
 
 ## TODO
 
-**IMPORTANT:** Kops terraform output (`kops update cluster --target terraform`) is still generated for Terraform `0.11.x` 
+1. **IMPORTANT:** Kops terraform output (`kops update cluster --target terraform`) is still generated for Terraform `0.11.x` 
       (https://github.com/kubernetes/kops/issues/7052) we'll take care of the migration when `tf-0.12` gets fully supported.
 
+2. Create a Binbash Leverage public Confluence Wiki entry detailing some more info about etcd, calico and k8s versions
+compatibilities
 ---
 
 # Release Management


### PR DESCRIPTION
#### Commits on Jan 27, 2020
- @exequielrafaela - BBL-80 adding cluster name sufix to kops state bucket name for multi-cluster single account support - ad8c748
- @exequielrafaela - BBL-80 Fully parametrized cluster template in place - README.md updated to extend related doc - 37e2ff7
- @exequielrafaela - BBL-80 Makefile updated with tf dockerized apply cmd + Makefile.kubectl for dockerized K8s mgmt. - e70943c